### PR TITLE
Implement App Scaffold

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,12 @@
-<link href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=Rubik:wght@400;500;700&display=swap" rel="stylesheet">
+<link
+  href="https://fonts.googleapis.com/css2?family=Kosugi+Maru&family=Rubik:wght@400;500;700&display=swap"
+  rel="stylesheet"
+/>
+<style>
+  html,
+  #root,
+  .sb-show-main {
+    height: 100%;
+    width: 100%;
+  }
+</style>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,10 +4,4 @@ import { withA11y } from '@storybook/addon-a11y';
 
 import '../src/sass/main.scss';
 
-addDecorator(storyFn => (
-  <div style={{ padding: '2rem' }}>
-    {storyFn()}
-  </div>
-));
-
 addDecorator(withA11y);

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,5 +6,6 @@ module.exports = {
   ],
   rules: {
     'max-nesting-depth': 2,
+    'selector-max-id': 1,
   },
 };

--- a/src/components/Scaffold/Scaffold.jsx
+++ b/src/components/Scaffold/Scaffold.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Logo } from '../Logo/Logo';
+import GithubLink from '../GithubLink/GithubLink';
+import Timer from '../Timer/Timer';
+
+import './Scaffold.scss';
+
+export const Scaffold = ({ children }) => (
+  <div className="scaffold">
+    <header className="scaffold__header">
+      <Logo fill="default" size="md"></Logo>
+      <Timer minutes={1} seconds={0}></Timer>
+    </header>
+    <main className="scaffold__main">{children}</main>
+    <footer className="scaffold__footer">
+      <GithubLink />
+    </footer>
+  </div>
+);
+
+Scaffold.propTypes = {
+  children: PropTypes.element,
+};

--- a/src/components/Scaffold/Scaffold.scss
+++ b/src/components/Scaffold/Scaffold.scss
@@ -1,0 +1,24 @@
+.scaffold {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  margin: 0 auto;
+  max-width: 120rem;
+
+  &__header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-top: 8rem;
+  }
+
+  &__main {
+    flex: 1;
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 8rem;
+  }
+}

--- a/src/components/Scaffold/Scaffold.stories.jsx
+++ b/src/components/Scaffold/Scaffold.stories.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { Scaffold } from './Scaffold';
+
+export default {
+  title: 'Scaffold',
+  component: Scaffold,
+};
+
+export const Default = () => <Scaffold>This is my app</Scaffold>;

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,6 @@
 
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root" class="root"></div>
+    <div id="root"></div>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,6 @@
 
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root" class="root"></div>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './sass/main.scss';
-import { Tooltip, Icon } from './components';
+import { Scaffold } from './components/Scaffold/Scaffold';
 
-const App = () => (
-  <div>
-    <Tooltip>Hello World!!</Tooltip>
-    <Icon name="github" />
-  </div>
-);
-
+const App = () => <Scaffold>asdfsd</Scaffold>;
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/src/sass/base/_home.scss
+++ b/src/sass/base/_home.scss
@@ -6,8 +6,9 @@ html {
 
 body {
   @include text-sm;
+  background-color: $color--lavendar;
+  color: $color--dusk;
   font-family: $font-family--primary;
   font-weight: $font-weight--medium;
   line-height: $font-height--xs;
-  color: $color--dusk;
 }

--- a/src/sass/base/_reset.scss
+++ b/src/sass/base/_reset.scss
@@ -8,6 +8,6 @@
 
 html,
 body,
-.root {
+#root {
   height: 100%;
 }

--- a/src/sass/base/_reset.scss
+++ b/src/sass/base/_reset.scss
@@ -1,7 +1,13 @@
 *,
 *::after,
 *::before {
+  box-sizing: inherit;
   margin: 0;
   padding: 0;
-  box-sizing: inherit;
+}
+
+html,
+body,
+.root {
+  height: 100%;
 }


### PR DESCRIPTION
Utilized Logo, Timer, and Github Link

These three components are rendered in scaffold as required to fit the
zeplin mockup.

Currently only accepts children prop but in the future should
accept props that are used in Logo and Timer as well.

In home.scss I added a background color to the whole body.

In reset.scss I added 100% height to root, html, and body so that the page
renders the scaffold at 100%

Currently index.js is rendering App which only returns the scaffold.

May want to split App into a separate file, but this works for now.

Resolves #38 
